### PR TITLE
Add reference documentation link to SIP-53

### DIFF
--- a/content/quote-pattern-type-variable-syntax.md
+++ b/content/quote-pattern-type-variable-syntax.md
@@ -27,6 +27,8 @@ Namely when using explicit type variable definitions.
 
 ### Background
 
+* [Reference Documentation](http://dotty.epfl.ch/docs/reference/metaprogramming/macros.html#type-variables)
+
 Quoted expressions support two ways of defining type variables: explicit and nested.
 
 ##### Explicit type variables


### PR DESCRIPTION
Given https://github.com/scala/improvement-proposals/pull/59#issuecomment-1525489918 we should have an explicit link to this documentation.