### PR TITLE
Match types: fix wildcard captures handling to match intent.

### DIFF
--- a/content/match-types-spec.md
+++ b/content/match-types-spec.md
@@ -253,8 +253,9 @@ At the top level, `variance = 1` and `scrutIsWidenedAbstract = false`.
 * If `P` is a `TypeWithoutCapture`:
   * Do nothing (always succeed).
 * If `P` is a `WildcardCapture` `ti = _`:
-  * If `X` is of the form `_ >: L <: H`, instantiate `ti := H` (anything between `L` and `H` would work here),
-  * Otherwise, instantiate `ti := X`.
+  * Instantiate `ti` so that the subtype test in Step (2) above always succeeds:
+    * If `X` is of the form `_ >: L <: H`, instantiate `ti := H` (resp. `L`, `X`) if `variance = 1` (resp. `-1`, `0`).
+    * Otherwise, instantiate `ti := X`.
 * If `P` is a `TypeCapture` `ti`:
   * If `X` is of the form `_ >: L <: H`,
     * If `scrutIsWidenedAbstract` is `true`, fail as not specific.


### PR DESCRIPTION
As demonstrated by https://github.com/lampepfl/dotty/issues/19607, picking `H` does *not* in fact always work. It was always the intent of the spec to pick an instantiation that would make subtyping work, but the particular choice was wrong.

IMO this is therefore clearly a spec bug, and we can address it irrespective of compatibility concerns.

---

Companion PR to fix it in the compiler: https://github.com/lampepfl/dotty/pull/19627