### PR TITLE
Fix typo

### DIFF
--- a/content/named-tuples.md
+++ b/content/named-tuples.md
@@ -230,7 +230,7 @@ and singleton types with case classes as underlying type (in terms of the implem
 We allow named patterns not just for named tuples but also for case classes. For instance:
 ```scala
 city match
-  case c @ City(name = "London") => println(p.population)
+  case c @ City(name = "London") => println(c.population)
   case City(name = n, zip = 1026, population = pop) => println(pop)
 ```
 


### PR DESCRIPTION
I think a small typo managed to sneak in,  shouldn't it be 'c.population' rather than 'p.population'