### PR TITLE
chore: retire scala-improvement-bot account

### DIFF
--- a/.github/scripts/generate-docs.scala
+++ b/.github/scripts/generate-docs.scala
@@ -14,7 +14,7 @@ import io.circe.{ Json, yaml }
 import scala.annotation.tailrec
 import scala.sys.process.Process
 
-val gitToken = sys.env("IMPROVEMENT_BOT_TOKEN")
+val gitToken = sys.env("BOT_TOKEN")
 val yamlPrinter = yaml.Printer(preserveOrder = true)
 
 /**
@@ -43,8 +43,8 @@ def clone(repo: String, branch: String): os.Path =
   val url = s"https://x-access-token:${gitToken}@github.com/${repo}"
   val path = os.temp.dir()
   run(s"git clone --branch ${branch} ${url} ${path}", os.pwd)
-  run(s"git config user.name \"Scala Improvement Bot\"", path)
-  run(s"git config user.email scala.improvement@epfl.ch", path)
+  run(s"git config user.name \"dottybot\"", path)
+  run(s"git config user.email dottybot@groupes.epfl.ch", path)
   path
 
 // Invoke command and make sure it succeeds. For some reason, os.proc(cmd).call(cwd) does not work.

--- a/.github/workflows/generate-docs.yaml
+++ b/.github/workflows/generate-docs.yaml
@@ -12,5 +12,5 @@ jobs:
       - uses: actions/checkout@v3
       - name: Generate SIP documentation
         env:
-          IMPROVEMENT_BOT_TOKEN: ${{ secrets.IMPROVEMENT_BOT_TOKEN }}
+          BOT_TOKEN: ${{ secrets.BOT_TOKEN }}
         run: scala-cli .github/scripts/generate-docs.scala


### PR DESCRIPTION
We are retiring the `scala-improvement-bot` in favor of our main bot account `dottybot`