### PR TITLE
SIP-68: Reference-able Package Objects

### DIFF
--- a/content/068-reference-package-objects.md
+++ b/content/068-reference-package-objects.md
@@ -252,3 +252,4 @@ index b820dff8c3..29ba15bcdd 100644
  
    override def multiType: Array[TypeResult] = {
 ```
+


### PR DESCRIPTION
This is a stub for SIP-68, to be retained until it is shipped. The original PR and discussion can be found [here](https://github.com/scala/improvement-proposals/pull/100).