### PR TITLE
SIP-61: Unroll Default Arguments for Binary Compatibility

### DIFF
--- a/content/061-unroll-default-arguments.md
+++ b/content/061-unroll-default-arguments.md
@@ -933,3 +933,4 @@ artifacts and can be used in your own projects already:
 
 - Compiler Plugin: `ivy"com.lihaoyi::unroll-plugin:0.1.12"`
 - Annotation: `ivy"com.lihaoyi::unroll-annotation:0.1.12"`
+


### PR DESCRIPTION
This is a stub for SIP-61, to be retained until it is shipped. The original PR and discussion can be found [here](https://github.com/scala/improvement-proposals/pull/78).