### PR TITLE
Tweak number-based permalinks

### DIFF
--- a/content/001-named-and-default-arguments.md
+++ b/content/001-named-and-default-arguments.md
@@ -2,9 +2,11 @@
 kind: SID
 layout: sip
 number: 1
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/named-and-default-arguments.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/named-and-default-arguments.html
 stage: completed
 status: shipped
 title: Named and Default Arguments

--- a/content/002-scala-compiler-phase-plugin-in.md
+++ b/content/002-scala-compiler-phase-plugin-in.md
@@ -2,9 +2,11 @@
 kind: SID
 layout: sip
 number: 2
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/scala-compiler-phase-plugin-in.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/scala-compiler-phase-plugin-in.html
 stage: completed
 status: shipped
 title: Scala Compiler Phase and Plug-In Initialization for Scala 2.8

--- a/content/003-new-collection-classes.md
+++ b/content/003-new-collection-classes.md
@@ -2,9 +2,11 @@
 kind: SID
 layout: sip
 number: 3
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/new-collection-classes.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/new-collection-classes.html
 stage: completed
 status: shipped
 title: New Collection classes

--- a/content/004-early-member-definitions.md
+++ b/content/004-early-member-definitions.md
@@ -2,9 +2,11 @@
 kind: SID
 layout: sip
 number: 4
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/early-member-definitions.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/early-member-definitions.html
 stage: completed
 status: shipped
 title: Early Member Definitions

--- a/content/005-internals-of-scala-annotations.md
+++ b/content/005-internals-of-scala-annotations.md
@@ -2,9 +2,11 @@
 kind: SID
 layout: sip
 number: 5
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/internals-of-scala-annotations.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/internals-of-scala-annotations.html
 stage: completed
 status: shipped
 title: Internals of Scala Annotations

--- a/content/007-scala-2-8-arrays.md
+++ b/content/007-scala-2-8-arrays.md
@@ -2,9 +2,11 @@
 kind: SID
 layout: sip
 number: 7
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/scala-2-8-arrays.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/scala-2-8-arrays.html
 stage: completed
 status: shipped
 title: Scala 2.8 Arrays

--- a/content/008-scala-swing-overview.md
+++ b/content/008-scala-swing-overview.md
@@ -2,9 +2,11 @@
 kind: SID
 layout: sip
 number: 8
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/scala-swing-overview.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/scala-swing-overview.html
 stage: completed
 status: shipped
 title: Scala Swing Overview

--- a/content/009-scala-specialization.md
+++ b/content/009-scala-specialization.md
@@ -2,9 +2,11 @@
 kind: SID
 layout: sip
 number: 9
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/scala-specialization.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/scala-specialization.html
 stage: completed
 status: shipped
 title: Scala Specialization

--- a/content/010-picked-signatures.md
+++ b/content/010-picked-signatures.md
@@ -2,9 +2,11 @@
 kind: SID
 layout: sip
 number: 10
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/picked-signatures.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/picked-signatures.html
 stage: completed
 status: shipped
 title: Storage of pickled Scala signatures in class files

--- a/content/011-string-interpolation.md
+++ b/content/011-string-interpolation.md
@@ -1,9 +1,11 @@
 ---
 layout: sip
 number: 11
-permalink: /sips/:number
-redirect_from: /sips/string-interpolation.html
-redirect_from: /sips/pending/string-interpolation.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/string-interpolation.html
+  - /sips/pending/string-interpolation.html
 stage: completed
 status: shipped
 title: String Interpolation

--- a/content/013-implicit-classes.md
+++ b/content/013-implicit-classes.md
@@ -1,9 +1,11 @@
 ---
 layout: sip
 number: 13
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/implicit-classes.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/implicit-classes.html
 stage: completed
 status: shipped
 title: Implicit classes

--- a/content/014-futures-promises.md
+++ b/content/014-futures-promises.md
@@ -1,9 +1,11 @@
 ---
 layout: sip
 number: 14
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/futures-promises.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/futures-promises.html
 stage: completed
 status: shipped
 title: Futures and Promises

--- a/content/015-value-classes.md
+++ b/content/015-value-classes.md
@@ -1,9 +1,11 @@
 ---
 layout: sip
 number: 15
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/value-classes.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/value-classes.html
 stage: completed
 status: shipped
 title: Value Classes

--- a/content/017-type-dynamic.md
+++ b/content/017-type-dynamic.md
@@ -1,9 +1,11 @@
 ---
 layout: sip
 number: 17
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/type-dynamic.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/type-dynamic.html
 stage: completed
 status: shipped
 title: Type Dynamic

--- a/content/018-modularizing-language-features.md
+++ b/content/018-modularizing-language-features.md
@@ -1,9 +1,11 @@
 ---
 layout: sip
 number: 18
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/modularizing-language-features.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/modularizing-language-features.html
 stage: completed
 status: shipped
 title: Modularizing Language Features

--- a/content/023-42.type.md
+++ b/content/023-42.type.md
@@ -1,9 +1,11 @@
 ---
 layout: sip
 number: 23
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/42.type.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/42.type.html
 stage: completed
 status: shipped
 title: Literal-based singleton types

--- a/content/025-trait-parameters.md
+++ b/content/025-trait-parameters.md
@@ -1,9 +1,11 @@
 ---
 layout: sip
 number: 25
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/trait-parameters.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/trait-parameters.html
 stage: completed
 status: shipped
 title: Trait Parameters

--- a/content/027-trailing-commas.md
+++ b/content/027-trailing-commas.md
@@ -1,9 +1,11 @@
 ---
 layout: sip
 number: 27
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/trailing-commas.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/trailing-commas.html
 stage: completed
 status: shipped
 title: Trailing Commas

--- a/content/030-static-members.md
+++ b/content/030-static-members.md
@@ -1,9 +1,11 @@
 ---
 layout: sip
 number: 30
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/static-members.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/static-members.html
 stage: completed
 status: shipped
 title: "@static fields and methods in Scala objects (SI-4581)"

--- a/content/031-byname-implicits.md
+++ b/content/031-byname-implicits.md
@@ -1,9 +1,11 @@
 ---
 layout: sip
 number: 31
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/byname-implicits.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/byname-implicits.html
 stage: completed
 status: shipped
 title: Byname implicit arguments

--- a/content/033-priority-based-infix-type-precedence.md
+++ b/content/033-priority-based-infix-type-precedence.md
@@ -1,9 +1,11 @@
 ---
 layout: sip
 number: 33
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/priority-based-infix-type-precedence.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/priority-based-infix-type-precedence.html
 stage: completed
 status: shipped
 title: Priority-based infix type precedence

--- a/content/035-opaque-types.md
+++ b/content/035-opaque-types.md
@@ -1,9 +1,11 @@
 ---
 layout: sip
 number: 35
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/opaque-types.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/opaque-types.html
 stage: completed
 status: shipped
 title: Opaque types

--- a/content/037-interpolation-quote-escape.md
+++ b/content/037-interpolation-quote-escape.md
@@ -1,9 +1,11 @@
 ---
 layout: sip
 number: 37
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/interpolation-quote-escape.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/interpolation-quote-escape.html
 stage: completed
 status: shipped
 title: Quote escapes for interpolations

--- a/content/038-converters-among-optional-functions-partialfunctions-and-extractor-objects.md
+++ b/content/038-converters-among-optional-functions-partialfunctions-and-extractor-objects.md
@@ -1,9 +1,11 @@
 ---
 layout: sip
 number: 38
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/converters-among-optional-functions-partialfunctions-and-extractor-object.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/converters-among-optional-functions-partialfunctions-and-extractor-object.html
 stage: completed
 status: shipped
 title: Converters among optional Functions, PartialFunctions and extractor objects

--- a/content/039-right-associative-by-name-operators.md
+++ b/content/039-right-associative-by-name-operators.md
@@ -1,9 +1,11 @@
 ---
 layout: sip
 number: 39
-permalink: /sips/:number
-redirect_from: /sips/:title.html
-redirect_from: /sips/pending/right-associative-by-name-operators.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
+  - /sips/pending/right-associative-by-name-operators.html
 stage: completed
 status: shipped
 title: Right-Associative By-Name Operators

--- a/content/042-binary-integer-literals.md
+++ b/content/042-binary-integer-literals.md
@@ -1,8 +1,10 @@
 ---
 layout: sip
 number: 42
-permalink: /sips/:number
-redirect_from: /sips/:title.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
 stage: completed
 status: shipped
 title: Support Binary Integer Literals

--- a/content/044-fewer-braces.md
+++ b/content/044-fewer-braces.md
@@ -1,8 +1,10 @@
 ---
 layout: sip
 number: 44
-permalink: /sips/:number
-redirect_from: /sips/:title.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
 stage: completed
 status: shipped
 title: Fewer Braces

--- a/content/046-scala-cli.md
+++ b/content/046-scala-cli.md
@@ -1,8 +1,10 @@
 ---
 layout: sip
 number: 46
-permalink: /sips/:number
-redirect_from: /sips/:title.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
 stage: completed
 status: shipped
 title: Scala CLI as default Scala command

--- a/content/047-clause-interleaving.md
+++ b/content/047-clause-interleaving.md
@@ -1,8 +1,10 @@
 ---
 layout: sip
 number: 47
-permalink: /sips/:number
-redirect_from: /sips/:title.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
 stage: completed
 status: shipped
 title: Clause Interleaving

--- a/content/049-polymorphic-eta-expansion.md
+++ b/content/049-polymorphic-eta-expansion.md
@@ -1,8 +1,10 @@
 ---
 layout: sip
 number: 49
-permalink: /sips/:number
-redirect_from: /sips/:title.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
 stage: implementation
 status: waiting-for-implementation
 title: Polymorphic Eta-Expansion

--- a/content/051-drop-stdlib-forwards-bin-compat.md
+++ b/content/051-drop-stdlib-forwards-bin-compat.md
@@ -1,8 +1,10 @@
 ---
 layout: sip
 number: 51
-permalink: /sips/:number
-redirect_from: /sips/:title.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
 stage: completed
 status: shipped
 title: Drop Forwards Binary Compatibility of the Scala 2.13 Standard Library

--- a/content/052-binary-api.md
+++ b/content/052-binary-api.md
@@ -1,8 +1,10 @@
 ---
 layout: sip
 number: 52
-permalink: /sips/:number
-redirect_from: /sips/:title.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
 stage: completed
 status: shipped
 title: Binary APIs

--- a/content/053-quote-pattern-type-variable-syntax.md
+++ b/content/053-quote-pattern-type-variable-syntax.md
@@ -1,8 +1,10 @@
 ---
 layout: sip
 number: 53
-permalink: /sips/:number
-redirect_from: /sips/:title.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
 stage: completed
 status: shipped
 title: Quote pattern explicit type variable syntax

--- a/content/054-multi-source-extension-overloads.md
+++ b/content/054-multi-source-extension-overloads.md
@@ -1,8 +1,10 @@
 ---
 layout: sip
 number: 54
-permalink: /sips/:number
-redirect_from: /sips/:title.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
 stage: completed
 status: shipped
 title: Multi-Source Extension Overloads

--- a/content/056-match-types-spec.md
+++ b/content/056-match-types-spec.md
@@ -1,8 +1,10 @@
 ---
 layout: sip
 number: 56
-permalink: /sips/:number
-redirect_from: /sips/:title.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
 stage: completed
 status: shipped
 title: Proper Specification for Match Types

--- a/content/057-replace-nonsensical-unchecked-annotation.md
+++ b/content/057-replace-nonsensical-unchecked-annotation.md
@@ -1,8 +1,10 @@
 ---
 layout: sip
 number: 57
-permalink: /sips/:number
-redirect_from: /sips/:title.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
 presip-thread: https://contributors.scala-lang.org/t/pre-sip-replace-non-sensical-unchecked-annotations/6342
 stage: completed
 status: shipped

--- a/content/058-named-tuples.md
+++ b/content/058-named-tuples.md
@@ -1,8 +1,10 @@
 ---
 layout: sip
 number: 58
-permalink: /sips/:number
-redirect_from: /sips/named-tuples.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/named-tuples.html
 presip-thread: https://contributors.scala-lang.org/t/pre-sip-named-tuples/6403/164
 stage: completed
 status: shipped

--- a/content/059-multiple-assignments.md
+++ b/content/059-multiple-assignments.md
@@ -1,8 +1,10 @@
 ---
 layout: sip
 number: 59
-permalink: /sips/:number
-redirect_from: /sips/:title.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
 presip-thread: https://contributors.scala-lang.org/t/pre-sip-multiple-assignments/6425
 stage: implementation
 status: under-review

--- a/content/060-alternative-bind-variables.md
+++ b/content/060-alternative-bind-variables.md
@@ -1,8 +1,10 @@
 ---
 layout: sip
 number: 60
-permalink: /sips/:number
-redirect_from: /sips/:title.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
 presip-thread: https://contributors.scala-lang.org/t/pre-sip-bind-variables-for-alternative-patterns/6321/13
 stage: implementation
 status: waiting-for-implementation

--- a/content/061-unroll-default-arguments.md
+++ b/content/061-unroll-default-arguments.md
@@ -1,8 +1,10 @@
 ---
 layout: sip
 number: 61
-permalink: /sips/:number
-redirect_from: /sips/:title.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
 stage: completed
 status: accepted
 title: Unroll Default Arguments for Binary Compatibility

--- a/content/062-better-fors.md
+++ b/content/062-better-fors.md
@@ -1,8 +1,10 @@
 ---
 layout: sip
 number: 62
-permalink: /sips/:number
-redirect_from: /sips/:title.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
 stage: completed
 status: shipped
 title: For comprehension improvements

--- a/content/064-typeclasses-syntax.md
+++ b/content/064-typeclasses-syntax.md
@@ -1,8 +1,10 @@
 ---
 layout: sip
 number: 64
-permalink: /sips/:number
-redirect_from: /sips/:title.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
 presip-thread: https://contributors.scala-lang.org/t/pre-sip-improve-syntax-for-context-bounds-and-givens/6576/97
 stage: completed
 status: shipped

--- a/content/068-reference-package-objects.md
+++ b/content/068-reference-package-objects.md
@@ -1,8 +1,10 @@
 ---
 layout: sip
 number: 68
-permalink: /sips/:number
-redirect_from: /sips/:title.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/:title.html
 stage: completed
 status: accepted
 title: Reference-able Package Objects

--- a/content/071-into.md
+++ b/content/071-into.md
@@ -1,7 +1,9 @@
 ---
 layout: sip
-permalink: /sips/:number
-redirect_from: /sips/into.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:number
+  - /sips/into.html
 stage: completed
 status: shipped
 number: 71

--- a/sip-template.md
+++ b/sip-template.md
@@ -1,8 +1,10 @@
 ---
 layout: sip
 number: NN
-permalink: /sips/:number
-redirect_from: /sips/:title.html
+permalink: /sips/:number.html
+redirect_from:
+  - /sips/:title.html
+  - /sips/:number
 stage: implementation
 status: waiting-for-implementation
 presip-thread: https://contributors.scala-lang.org/t/pre-sip-foo-bar/9999


### PR DESCRIPTION
Support `sips/nn` which redirects to `sips/nn.html` while keeping other redirects (custom and based on the title).